### PR TITLE
Update resources.py

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -1119,7 +1119,7 @@ class Resource(metaclass=DeclarativeMetaclass):
         Return a list of field names, respecting any defined ordering.
         """
         # get any declared 'order' fields
-        order_fields = getattr(self._meta, order_field) or ()
+        order_fields = tuple(getattr(self._meta, order_field) or ())
         # get any defined fields
         defined_fields = order_fields + tuple(getattr(self._meta, "fields") or ())
 


### PR DESCRIPTION
Cast tuple onto the Meta order_fields so they can concatenate with the Meta fields.

On a class inheriting `resources.ModelResource`, when fields and order_fields are defined as list in the class' Meta, tuple is cast onto the `fields `attribute but not onto the `order_fields`.

This results in the TypeError on line 1121 coming from the line `defined_fields = order_fields + tuple(getattr(self._meta, "fields") or ()`

(.../import_export/resources.py)

What problem have you solved?

![TypeError](https://github.com/Klexus1/django-import-export/assets/47198827/50089a39-4f09-4759-b2d9-1a3bf07df324)

Now both resources.ModelResource - Meta - fields and order_fields can be defined as list.

How did you solve the problem?

Casting the tuple build in function onto the order_fields too.
